### PR TITLE
Wiki search

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,4 +11,9 @@ The DELPH-IN wiki now lives on GitHub, [here](https://github.com/delph-in/docs/w
   </form>
 </div>
 
-[The 2021 summit](https://github.com/delph-in/docs/wiki/Virtual2021Participants) is taking place online, July 19--23.
+# Summits
+
+The last summit
+([2021](https://github.com/delph-in/docs/wiki/Virtual2021Top)) was
+held online, July 19--23. For links to previous summits, see the
+[SummitTop](https://github.com/delph-in/docs/wiki/SummitTop) wiki.

--- a/index.md
+++ b/index.md
@@ -1,5 +1,14 @@
-# Welcome to DELPH-IN wiki
+
+# Wiki
 
 The DELPH-IN wiki now lives on GitHub, [here](https://github.com/delph-in/docs/wiki).
+
+<div style="text-align:center; font-size:larger">
+  <form action="https://github.com/delph-in/docs/search" method="GET" accept-charset="utf-8">
+    <input type="text" name="q" placeholder="Search the DELPH-IN wiki" size="32">
+    <input type="hidden" name="type" value="wikis">
+    <button type="submit">Search</button>
+  </form>
+</div>
 
 [The 2021 summit](https://github.com/delph-in/docs/wiki/Virtual2021Participants) is taking place online, July 19--23.


### PR DESCRIPTION
This commit adds a form that submits search queries to GitHub limited to the wiki pages. The form appears on the published docs website: https://delph-in.github.io/docs/

I tested the HTML but have not tested if it works in the `index.md` file. I'm not really sure of an easy way to test it, so I suggest we merge (if it otherwise looks good) and revise later.