### PR TITLE
remove "See on Github"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,4 @@
 theme: jekyll-theme-cayman
 title: DELPH-IN wiki portal
+github:
+  is_project_page: false


### PR DESCRIPTION
I suggest we remove the "See on Github" button from the front site? No need for the public to have a link directly to the repo code? Of course it's a public repo but I still usually think this button is not needed. What do others think?