### PR TITLE
sortinfo as optional

### DIFF
--- a/schemas/dmrs.dtd
+++ b/schemas/dmrs.dtd
@@ -8,7 +8,7 @@
           surface   CDATA #IMPLIED 
           ident     CDATA #IMPLIED >
 
-<!ELEMENT node ((realpred|gpred), sortinfo)>
+<!ELEMENT node ((realpred|gpred), sortinfo?)>
 <!ATTLIST node
           nodeid CDATA #REQUIRED
           cfrom CDATA #REQUIRED


### PR DESCRIPTION

In #15, I proposed to add here the DTD specifications of our semantic representations. 

1. What tools depend on these files? 
2. as far as I understood, quantifiers do not have sortinfo attached to them in a DRMS graph, if that is the case, I am proposing to add it as an optional tag for nodes. 