### PR TITLE
Fairhaven update

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,7 +13,46 @@ The DELPH-IN wiki now lives on GitHub, [here](https://github.com/delph-in/docs/w
 
 # Summits
 
-The last summit
-([2021](https://github.com/delph-in/docs/wiki/Virtual2021Top)) was
-held online, July 19--23. For links to previous summits, see the
+| Year | Venue                  | Dates             |
+|------|------------------------|-------------------|
+| 2023 | TBD                    | TBD               |
+| 2022 | [Fairhaven][]          | July 18--22       |
+| 2021 | [Virtual][Virtual2021] | July 19--23       |
+| 2020 | [Virtual][Virtual2020] | July 13--17       |
+| 2019 | [Cambridge][]          | July 15--19       |
+| 2018 | [Paris-Diderot][]      | July 18--22       |
+| 2017 | [Oslo][]               | August 7--11      |
+| 2016 | [Stanford][]           | June 16--20       |
+| 2015 | [Singapore][]          | August 3--7       |
+| 2014 | [Tomar][]              | July 14--18       |
+| 2013 | [Saarland][]           | July 29--August 2 |
+| 2012 | [Sofia][]              | July 2--6         |
+| 2011 | [Suquamish][]          | June 25--29       |
+| 2010 | [Paris][]              | July 2--6         |
+| 2009 | [Barcelona][]          | July 20--24       |
+| 2008 | [Kyoto][]              | July 31--August 3 |
+| 2007 | [Berlin][]             | August 20--24     |
+| 2006 | [Fefor][]              | June 12--17       |
+| 2005 | [Lisbon][]             | August 18--20     |
+
+[Fairhaven]: https://github.com/delph-in/docs/wiki/FairhavenTop
+[Virtual2021]: https://github.com/delph-in/docs/wiki/Virtual2021Top
+[Virtual2020]: https://github.com/delph-in/docs/wiki/BellinghamTop
+[Cambridge]: https://github.com/delph-in/docs/wiki/CambridgeTop
+[Paris-Diderot]: https://github.com/delph-in/docs/wiki/DiderotTop
+[Oslo]: https://github.com/delph-in/docs/wiki/OsloTop
+[Stanford]: https://github.com/delph-in/docs/wiki/StanfordTop
+[Singapore]: https://github.com/delph-in/docs/wiki/SingaporeTop
+[Tomar]: https://github.com/delph-in/docs/wiki/TomarTop
+[Saarland]: https://github.com/delph-in/docs/wiki/SaarlandTop
+[Sofia]: https://github.com/delph-in/docs/wiki/SofiaTop
+[Suquamish]: https://github.com/delph-in/docs/wiki/SuquamishTop
+[Paris]: https://github.com/delph-in/docs/wiki/ParisTop
+[Barcelona]: https://github.com/delph-in/docs/wiki/BarcelonaTop
+[Kyoto]: https://github.com/delph-in/docs/wiki/KyotoTop
+[Berlin]: https://github.com/delph-in/docs/wiki/BerlinTop
+[Fefor]: https://github.com/delph-in/docs/wiki/FeforTop
+[Lisbon]: https://github.com/delph-in/docs/wiki/LisbonTop
+
+More information is at the
 [SummitTop](https://github.com/delph-in/docs/wiki/SummitTop) wiki.

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 
-# Wiki
+# DELPH-IN Documentation
 
 The DELPH-IN wiki now lives on GitHub, [here](https://github.com/delph-in/docs/wiki).
 


### PR DESCRIPTION
Updating the published front page with all previous summits. I also changed the title from "Wiki" to "DELPH-IN Documentation"