### PR TITLE
CI hygiene: bump deprecated action versions

### DIFF
--- a/.github/actions/buildindex/action.yml
+++ b/.github/actions/buildindex/action.yml
@@ -16,5 +16,5 @@ outputs:
     description: 'The time we greeted you'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/.github/workflows/BuildDocs.yml
+++ b/.github/workflows/BuildDocs.yml
@@ -51,14 +51,14 @@ jobs:
 
       # This repo
       - name: Checkout docs
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: main
           fetch-depth: 0
 
       # This repo's wiki (the Official docs wiki)
       - name: Checkout docs wiki repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: delph-in/docs.wiki
           path: docswiki

--- a/.github/workflows/DailyDocBuildIfWikiUpdates.yml
+++ b/.github/workflows/DailyDocBuildIfWikiUpdates.yml
@@ -62,7 +62,7 @@ jobs:
       # specified path, and overwrite the file created in the "Create cache file" step in the path
       - name: Check SHA
         id: check_sha
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: check-SHA
           key: check-SHA-${{ steps.head_sha.outputs.head_sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 env/
 __pycache__/
+.claude/
 
 **/.DS_Store
 


### PR DESCRIPTION
## Summary
Small, low-risk cleanup found while auditing the build pipeline for the BergenTop page-registration fix (merged directly to main separately, since it was time-sensitive with the 2026 Bergen summit imminent):

- `actions/checkout@v3` -> `v4` and `actions/cache@v3` -> `v4` in the workflows (v3 majors are EOL and depend on the deprecated Node 16 runtime)
- `buildindex` custom action: `node16` -> `node20` runtime (no Node-16-specific API usage in `index.js`, so this should be a no-op behaviorally)
- `.gitignore`: add `.claude/` so local Claude Code tool settings never get committed

## Not included (flagged, not fixed)
- `.github/actions/buildindex/node_modules/` is committed to the repo (482 files). Fixing that properly means bundling with `@vercel/ncc` into a single `dist/index.js`, which is a bigger change I didn't want to bundle into this low-risk PR.
- `createdocs.py`'s `get_change_text()` builds a `git log` shell command by interpolating a wiki filename unescaped (`subprocess.check_output([...], shell=True)`). Wiki filenames come from user-editable page titles, so this is worth hardening even though it isn't currently known to be exploitable.
- The reusable workflow reads inputs via `github.event.inputs.*`; for `workflow_call` triggers the correct context is `inputs.*`. Works today, but is the wrong context and could silently misbehave on other trigger paths.

## Test plan
- [ ] Confirm `BuildDocs` workflow still runs clean end-to-end on this branch (checkout/cache version bump shouldn't change behavior)
- [ ] Confirm the search index still builds correctly under Node 20 (buildindex action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)