### PR TITLE
Auto-prune registered pages whose wiki source has disappeared

### DIFF
--- a/.github/workflows/BuildDocs.yml
+++ b/.github/workflows/BuildDocs.yml
@@ -74,9 +74,11 @@ jobs:
       # createdocs.py already detects these as proposed fixes; this step auto-applies the safe ones
       # (pages that ARE linked to from an already-included page, so Site/Section is trustworthy) and
       # leaves genuinely unlinked/orphaned pages for a human to triage.
-      - name: Auto-register newly discoverable wiki pages
+      # It also prunes registered pages whose source file has actually disappeared (deleted/renamed
+      # wiki page), which otherwise fails the *entire* build until a human hand-edits the file.
+      - name: Auto-register new pages / prune stale ones
         id: autoregister
-        run: python $GITHUB_WORKSPACE/main/sitescripts/apply_new_pages.py $GITHUB_WORKSPACE/main/sitesdefinitions.json $GITHUB_WORKSPACE/main/latestsrc/FixesForBrokenLinksToWikiPages.json
+        run: python $GITHUB_WORKSPACE/main/sitescripts/apply_new_pages.py $GITHUB_WORKSPACE/main/sitesdefinitions.json $GITHUB_WORKSPACE/ $GITHUB_WORKSPACE/main/latestsrc/FixesForBrokenLinksToWikiPages.json
 
       # If new pages were registered above, re-run so latestsrc/latestsites actually include them
       # in this same build (otherwise they'd only appear after the next run)

--- a/sitescripts/apply_new_pages.py
+++ b/sitescripts/apply_new_pages.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import sys
@@ -8,6 +9,12 @@ import sys
 # aren't linked from anywhere in the built sites, so there's no reliable Site/Section
 # to file them under automatically.
 UNRESOLVED_SITE = "<not included or linked to>"
+
+# This Section name is a deliberate blackhole: it holds links to pages that are
+# never expected to exist (personal wiki-username pages, wiki system pages, etc),
+# used to suppress "broken link" reports. Entries here are meant to stay
+# FileMissing forever, so stale-page removal must never touch this section.
+IGNORE_SECTION = "<ignore>"
 
 
 def load(path):
@@ -69,6 +76,49 @@ def merge_new_pages(sitesdefinitions_tree, fixes_tree):
     return added
 
 
+# Registered pages whose source file has actually disappeared (deleted/renamed
+# wiki page) currently take down the *entire* build: createdocs.py throws trying
+# to open a nonexistent file and the whole run fails with "assert False" until a
+# human notices and hand-edits sitesdefinitions.json. This prunes those entries
+# instead -- but only once a page has been seen missing on two separate runs
+# (tracked via a "MissingSince" marker persisted back into sitesdefinitions.json),
+# as cheap insurance against a one-off flaky checkout wrongly deleting a real page.
+# The "<ignore>" section is a deliberate blackhole for permanently-missing pages
+# and is never touched.
+def remove_stale_pages(pages_tree, input_content_root):
+    removed = []
+    flagged = []
+    recovered = []
+
+    for site_name, sections in pages_tree.items():
+        for section in sections:
+            if section["Section"] == IGNORE_SECTION:
+                continue
+
+            surviving_pages = []
+            for page in section["Pages"]:
+                src_path = os.path.join(input_content_root, page["SrcDir"], page["SrcFile"])
+                if os.path.exists(src_path):
+                    if page.pop("MissingSince", None) is not None:
+                        recovered.append({"Site": site_name, "Section": section["Section"], "SrcFile": page["SrcFile"]})
+                    surviving_pages.append(page)
+                elif "MissingSince" in page:
+                    removed.append({"Site": site_name, "Section": section["Section"], "SrcFile": page["SrcFile"],
+                                     "MissingSince": page["MissingSince"]})
+                else:
+                    page["MissingSince"] = datetime.date.today().isoformat()
+                    flagged.append({"Site": site_name, "Section": section["Section"], "SrcFile": page["SrcFile"]})
+                    surviving_pages.append(page)
+
+            section["Pages"] = surviving_pages
+
+    # Drop sections that are now empty so the tree doesn't accumulate clutter
+    for site_name in list(pages_tree.keys()):
+        pages_tree[site_name] = [s for s in pages_tree[site_name] if s["Pages"]]
+
+    return removed, flagged, recovered
+
+
 # Render just the "Pages" tree in the same layout createdocs.py's
 # log_json_tree_to_file() uses, so that untouched entries produce an
 # unchanged diff and only newly added pages show up.
@@ -107,36 +157,52 @@ def write_sitesdefinitions(path, original_text, pages_tree):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print("Usage: apply_new_pages.py <sitesdefinitions.json> <FixesForBrokenLinksToWikiPages.json>")
+    if len(sys.argv) != 4:
+        print("Usage: apply_new_pages.py <sitesdefinitions.json> <input_content_root> <FixesForBrokenLinksToWikiPages.json>")
         sys.exit(1)
 
     sitesdefinitions_path = sys.argv[1]
-    fixes_path = sys.argv[2]
+    input_content_root = sys.argv[2]
+    fixes_path = sys.argv[3]
 
     with open(sitesdefinitions_path, "r") as txt_file:
         original_text = txt_file.read()
     sitesdefinitions_tree = json.loads(original_text)
 
-    if not os.path.exists(fixes_path):
-        print(f"No fixes file at {fixes_path}, nothing to do")
-        sys.exit(0)
+    added = []
+    if os.path.exists(fixes_path):
+        fixes_tree = load(fixes_path)
+        added = merge_new_pages(sitesdefinitions_tree, fixes_tree)
+    else:
+        print(f"No fixes file at {fixes_path}, skipping auto-add")
 
-    fixes_tree = load(fixes_path)
-
-    added = merge_new_pages(sitesdefinitions_tree, fixes_tree)
+    removed, flagged, recovered = remove_stale_pages(sitesdefinitions_tree["Pages"], input_content_root)
 
     github_output = os.environ.get("GITHUB_OUTPUT")
+    changed = bool(added or removed or flagged or recovered)
+
     if added:
-        write_sitesdefinitions(sitesdefinitions_path, original_text, sitesdefinitions_tree["Pages"])
         print(f"Added {len(added)} previously-unregistered page(s):")
         for entry in added:
             print(f'  {entry["Site"]} / {entry["Section"]}: {entry["SrcFile"]}')
-        if github_output:
-            with open(github_output, "a") as out:
-                out.write("changed=true\n")
+    if flagged:
+        print(f"Flagged {len(flagged)} page(s) as missing (will be removed if still missing next run):")
+        for entry in flagged:
+            print(f'  {entry["Site"]} / {entry["Section"]}: {entry["SrcFile"]}')
+    if removed:
+        print(f"Removed {len(removed)} page(s) confirmed missing since a prior run:")
+        for entry in removed:
+            print(f'  {entry["Site"]} / {entry["Section"]}: {entry["SrcFile"]} (missing since {entry["MissingSince"]})')
+    if recovered:
+        print(f"{len(recovered)} previously-flagged page(s) reappeared, unflagged:")
+        for entry in recovered:
+            print(f'  {entry["Site"]} / {entry["Section"]}: {entry["SrcFile"]}')
+
+    if changed:
+        write_sitesdefinitions(sitesdefinitions_path, original_text, sitesdefinitions_tree["Pages"])
     else:
-        print("No new pages to register")
-        if github_output:
-            with open(github_output, "a") as out:
-                out.write("changed=false\n")
+        print("No changes to sitesdefinitions.json")
+
+    if github_output:
+        with open(github_output, "a") as out:
+            out.write(f"changed={'true' if changed else 'false'}\n")


### PR DESCRIPTION
## Summary
Follow-up to the BergenTop auto-registration fix (already merged directly to main). This closes the other half of the gap: a registered page whose wiki file gets deleted or renamed currently takes down the **entire** site build, since `createdocs.py` throws `FileNotFoundError` trying to open it and the run fails until a human hand-edits `sitesdefinitions.json`.

- `apply_new_pages.py` now also removes stale `Pages` entries, but only once a page has been missing for **two separate runs** (tracked via a `"MissingSince"` marker persisted in `sitesdefinitions.json` itself) -- cheap insurance against a one-off flaky wiki checkout wrongly deleting a real page.
- If a flagged page reappears before the second run, the marker is cleared and nothing is removed.
- The `"<ignore>"` section is a deliberate blackhole for links to pages that are never expected to exist (personal wiki-username pages, wiki system pages) and is explicitly never touched by this logic.

## Testing
Ran a full local build against the real `delph-in/docs.wiki` checkout and:
- Confirmed a no-op run (nothing added/removed) produces zero diff
- Simulated `BergenSchedule.md` going missing: run 1 flagged it (kept), run 2 (still missing) removed it
- Simulated `BergenParticipants.md` going missing then reappearing before a second run: marker cleared, page kept
- Confirmed the `<ignore>` section (87 entries) was untouched throughout
- Confirmed `createdocs.py` still builds cleanly (exit 0) against the resulting file in every case

## Test plan
- [ ] Trigger `BuildDocs` on this branch (`workflow_dispatch`) once to confirm the new step runs cleanly in CI
- [ ] After merging, watch the next scheduled run's commit diff to confirm no unexpected removals

🤖 Generated with [Claude Code](https://claude.com/claude-code)