### PR TITLE
Trigger doc build on wiki edit (gollum event) instead of daily polling

### DIFF
--- a/.github/workflows/BuildDocsOnWikiEdit.yml
+++ b/.github/workflows/BuildDocsOnWikiEdit.yml
@@ -1,0 +1,25 @@
+name: BuildDocsOnWikiEdit
+
+# "gollum" fires as soon as a wiki page is created, edited, or renamed --
+# no polling, so new/updated pages go live within a single BuildDocs run
+# instead of waiting for the next scheduled check (see DailyDocBuildIfWikiUpdates.yml,
+# which still runs once a day as a fallback in case a gollum event is ever missed,
+# and to keep this repo from going dormant after 60 days of inactivity).
+on:
+  gollum:
+
+jobs:
+  build:
+    name: Build docs after a wiki edit
+    if: ${{ github.ref == 'refs/heads/main' }}
+    # Shared with DailyDocBuildIfWikiUpdates.yml's build job so back-to-back wiki
+    # edits queue their builds instead of racing the "commit + push to main" step
+    # in BuildDocs.yml.
+    concurrency:
+      group: builddocs-main
+      cancel-in-progress: false
+    # Call the shared workflow in this repo to do the actual build
+    uses: ./.github/workflows/BuildDocs.yml
+    with:
+      quickAndDirty: 'false'
+      externalUrlCheck: 'false'

--- a/.github/workflows/DailyDocBuildIfWikiUpdates.yml
+++ b/.github/workflows/DailyDocBuildIfWikiUpdates.yml
@@ -72,6 +72,12 @@ jobs:
     # Make sure check_if_wiki_changes has run first
     needs: check_if_wiki_changes
     if: contains(needs.check_if_wiki_changes.outputs.wiki_changed, 'true')
+    # Shared with BuildDocsOnWikiEdit.yml's build job so a gollum-triggered build
+    # and this daily fallback can never race the "commit + push to main" step in
+    # BuildDocs.yml -- they queue instead of running concurrently.
+    concurrency:
+      group: builddocs-main
+      cancel-in-progress: false
     # Call a shared workflow in the same repo to do the build
     uses: ./.github/workflows/BuildDocs.yml
     with:


### PR DESCRIPTION
## Summary
Prompted by "it's annoying to make a new page and not have it visible" -- currently a new/edited wiki page can take up to ~24h to show up on the live site, because `DailyDocBuildIfWikiUpdates.yml` only checks the wiki for changes once a day (06:45 UTC cron) before triggering a build.

- Adds `BuildDocsOnWikiEdit.yml`, using GitHub's built-in `gollum` event, which fires as soon as a wiki page is created, edited, or renamed. It calls the same shared `BuildDocs.yml` build used by the daily job, so a wiki edit goes live within a single ~6min build instead of waiting for the next scheduled check.
- The daily cron in `DailyDocBuildIfWikiUpdates.yml` is left in place as a fallback (in case a `gollum` event is ever dropped) and because it also handles the existing "force a build on the 1st/15th" workaround that keeps this repo from going dormant after 60 days of inactivity.
- Both build jobs now share a `concurrency: group: builddocs-main` (`cancel-in-progress: false`), so if someone edits several wiki pages back-to-back, the resulting builds queue instead of racing each other's `git commit -a && push` to `main` at the end of `BuildDocs.yml`.

## Not changed
- `BuildDocs.yml` itself is untouched -- both triggers call it exactly as before.
- Didn't bump the daily cron to hourly on top of this, since `gollum` makes polling latency largely moot; the daily run is now purely a safety net.

## Test plan
- [ ] Confirm YAML is valid (checked locally with `yaml.safe_load`, no `actionlint` available)
- [ ] After merging, edit a wiki page and confirm `BuildDocsOnWikiEdit` fires via the Actions tab and completes successfully
- [ ] Edit two wiki pages within a few seconds of each other and confirm the two triggered runs queue (via the concurrency group) rather than both attempting to push to `main` at once
- [ ] Confirm the daily `DailyDocBuildIfWikiUpdates` cron still runs and behaves as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)