### PR TITLE
Bump Node 20 actions to Node 24

### DIFF
--- a/.github/actions/buildindex/action.yml
+++ b/.github/actions/buildindex/action.yml
@@ -16,5 +16,5 @@ outputs:
     description: 'The time we greeted you'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'

--- a/.github/workflows/BuildDocs.yml
+++ b/.github/workflows/BuildDocs.yml
@@ -177,7 +177,7 @@ jobs:
 
 
       - name: Upload all the sites to github pages
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: main/latestsites/
 

--- a/.github/workflows/BuildDocs.yml
+++ b/.github/workflows/BuildDocs.yml
@@ -51,14 +51,14 @@ jobs:
 
       # This repo
       - name: Checkout docs
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: main
           fetch-depth: 0
 
       # This repo's wiki (the Official docs wiki)
       - name: Checkout docs wiki repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: delph-in/docs.wiki
           path: docswiki
@@ -96,26 +96,26 @@ jobs:
           ref-to-teaser-path: ./main/latestsites/refToTeaser.json
 
       # Upload any output data so users can get at it
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ failure() }}
         with:
           name: Site Errors
           path: main/latestsrc/SiteErrors.json
           if-no-files-found: ignore # 'warn' or 'ignore' are also available, defaults to `warn`
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: All Pages
           path: main/latestsrc/AllPages.json
           if-no-files-found: ignore # 'warn' or 'ignore' are also available, defaults to `warn`
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: All Links (working, broken, local, external, etc)
           path: main/latestsrc/AllLinks.json
           if-no-files-found: ignore # 'warn' or 'ignore' are also available, defaults to `warn`
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: Fixes for broken links To Wiki pages
           path: main/latestsrc/FixesForBrokenLinksToWikiPages.json
@@ -125,7 +125,7 @@ jobs:
 
       # Build each site with Jekyll
       - name: Setup Pages
-        uses: actions/configure-pages@v1
+        uses: actions/configure-pages@v6
 
       - name: Build Home with Jekyll
         uses: actions/jekyll-build-pages@v1
@@ -221,4 +221,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/DailyDocBuildIfWikiUpdates.yml
+++ b/.github/workflows/DailyDocBuildIfWikiUpdates.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Checkout the wiki
       - name: Checkout DELPH-IN wiki
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: delph-in/docs.wiki
           path: version_check
@@ -62,7 +62,7 @@ jobs:
       # specified path, and overwrite the file created in the "Create cache file" step in the path
       - name: Check SHA
         id: check_sha
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: check-SHA
           key: check-SHA-${{ steps.head_sha.outputs.head_sha }}


### PR DESCRIPTION
## Summary
- GitHub deprecated the Node 20 Actions runtime; runners now force Node 20 actions onto Node 24, which `actions/configure-pages@v1` can't handle, breaking the docs build during post-job cleanup (10/20 recent `BuildDocsOnWikiEdit` runs failing).
- Bumps `actions/checkout` v4→v7, `actions/upload-artifact` v4→v7, `actions/cache` v4→v6, `actions/configure-pages` v1→v6, and `actions/deploy-pages` v4→v5 — all now declare `node24`.
- Updates the local `./.github/actions/buildindex` composite action from `node20` to `node24`.

Fixes bond-lab/sleeper-service#2

## Test plan
- [ ] YAML validated with `yaml.safe_load` (done locally)
- [ ] Trigger `BuildDocs` via `workflow_dispatch` on this branch and confirm it completes without the post-job cleanup failure